### PR TITLE
Add multi tags search filter

### DIFF
--- a/Filter/Tags.php
+++ b/Filter/Tags.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Kanboard\Plugin\Creecros_Filter_Pack\Filter;
+
+use Kanboard\Core\Filter\FilterInterface;
+use Kanboard\Filter\BaseFilter;
+use Kanboard\Model\TagModel;
+use Kanboard\Model\TaskModel;
+use Kanboard\Model\TaskTagModel;
+use PicoDb\Database;
+use PicoDb\Table;
+
+
+class Tags extends BaseFilter implements FilterInterface
+{
+
+    private $db;
+
+    /**
+     * Current user id
+     *
+     * @access private
+     * @var int
+     */
+    private $currentUserId = 0;
+
+    /**
+     * Set current user id
+     *
+     * @access public
+     * @param  integer $userId
+     * @return TaskAssigneeFilter
+     */
+    public function setCurrentUserId($userId)
+    {
+        $this->currentUserId = $userId;
+        return $this;
+    }
+
+    public function setDatabase(Database $db)
+    {
+        $this->db = $db;
+        return $this;
+    }
+
+    /**
+     * Get search attribute
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getAttributes()
+    {
+        return array('tags');
+    }
+
+    /**
+     * Apply filter
+     *
+     * @access public
+     * @return string
+     */
+    public function apply()
+    {
+        $values = explode(",", $this->value);
+        if ($this->value === 'none') {
+            $sub_query = $this->getQueryOfTaskIdsWithoutTags();
+            $this->query->inSubquery(TaskModel::TABLE.'.id', $sub_query);
+            return $this;
+        } else {
+            foreach ($values as $value) {
+                $sub_query = $this->getQueryOfTaskIdsWithGivenTag($value);
+                $this->query->inSubquery(TaskModel::TABLE.'.id', $sub_query);
+            }
+            return $this;
+        }
+}
+
+    protected function getQueryOfTaskIdsWithoutTags()
+    {
+        return $this->db
+            ->table(TaskModel::TABLE)
+            ->columns(TaskModel::TABLE . '.id')
+            ->asc(TaskModel::TABLE . '.project_id')
+            ->left(TaskTagModel::TABLE, 'tg', 'task_id', TaskModel::TABLE, 'id')
+            ->isNull('tg.tag_id');
+    }
+
+    protected function getQueryOfTaskIdsWithGivenTag($value)
+    {
+        return $this->db
+            ->table(TagModel::TABLE)
+            ->columns(TaskTagModel::TABLE.'.task_id')
+            ->ilike(TagModel::TABLE.'.name', $value)
+            ->asc(TagModel::TABLE.'.project_id')
+            ->join(TaskTagModel::TABLE, 'tag_id', 'id');
+    }
+}

--- a/Plugin.php
+++ b/Plugin.php
@@ -3,6 +3,7 @@
 namespace Kanboard\Plugin\Creecros_Filter_Pack;
 
 use Kanboard\Core\Plugin\Base;
+use Kanboard\Plugin\Creecros_Filter_Pack\Filter\Tags;
 use Kanboard\Plugin\Creecros_Filter_Pack\Filter\Task_Subtask_Assignee;
 use Kanboard\Plugin\Creecros_Filter_Pack\Filter\SubtaskStatus;
 use Kanboard\Plugin\Creecros_Filter_Pack\Filter\SubtaskAssignee;
@@ -39,6 +40,14 @@ class Plugin extends Base
         //SubtaskAssignee Filter
         $this->container->extend('taskLexer', function($taskLexer, $c) {
             $taskLexer->withFilter(SubtaskAssignee::getInstance()
+                    ->setCurrentUserId($c['userSession']->getId())
+                    ->setDatabase($c['db']));
+            return $taskLexer;
+        });
+
+        //Tags Filter
+        $this->container->extend('taskLexer', function($taskLexer, $c) {
+            $taskLexer->withFilter(Tags::getInstance()
                     ->setCurrentUserId($c['userSession']->getId())
                     ->setDatabase($c['db']));
             return $taskLexer;

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@
 Example:
 - `task_subtask_assignee:name subtask:status:RUNNING status:open`
 
+
+### Tags
+
+- Use `tags:"<tag>,<tag>"` instead of multiples `tag:` to filter all task with the tag `a` *and* `b`. You can use as many tags you want in `tags:""` but they must be separated by `,`.


### PR DESCRIPTION
Hi,

first thanks for your plugin, it's has been more easier for me to create this filter.

Basically all I wanted is to have all the task with tags `a` **and** `b`, but with the default filter all I can do is to have task with tags `a` **or** `b`. Or I just don't know how to read the doc...

So I create this filter, it's use the following format `tags:"<tag>,<tag>"`. You can put any tag you want but it's not recommended to use with the default `tag:"<tag>"` otherwise you'll get side effects. But I don't see an user case with this two filter anyway.

What do you think?